### PR TITLE
Fix calculations when renderer size doesn't match canvas element size

### DIFF
--- a/src/multi-camera.js
+++ b/src/multi-camera.js
@@ -331,16 +331,20 @@ AFRAME.registerComponent('secondary-camera', {
           // "bottom" position is relative to the whole viewport, not just the canvas.
           // We need to turn this into a distance from the bottom of the canvas.
           // We need to consider the header bar above the canvas, and the size of the canvas.
-          const mainRect = renderer.domElement.getBoundingClientRect();
+          const canvas = renderer.domElement
+          const mainRect = canvas.getBoundingClientRect();
 
           renderer.getViewport(this.savedViewport);
           this.savedScissorTest = renderer.getScissorTest();
           renderer.getScissor(this.savedScissor);
 
-          this.outputRectangle.set(elemRect.left - mainRect.left,
-                                   mainRect.bottom - elemRect.bottom,
-                                   elemRect.width,
-                                   elemRect.height);
+          const hScale = 0.8 * canvas.width / mainRect.width 
+          const vScale = 0.8 * canvas.height / mainRect.height
+          this.outputRectangle.set(hScale * (elemRect.left - mainRect.left),
+                                   vScale * (mainRect.bottom - elemRect.bottom),
+                                   hScale * elemRect.width,
+                                   vScale * elemRect.height);
+
           renderer.setViewport(this.outputRectangle);
           renderer.setScissorTest(true);
           renderer.setScissor(this.outputRectangle);

--- a/src/multi-camera.js
+++ b/src/multi-camera.js
@@ -326,7 +326,7 @@ AFRAME.registerComponent('secondary-camera', {
         // don't bother rendering to screen in VR mode.
         if (this.data.output === "screen" && this.el.sceneEl.is('vr-mode')) return;
 
-        var elemRect;
+        let elemRect;
 
         if (this.data.output === "screen") {
             const elem = this.data.outputElement;
@@ -354,8 +354,10 @@ AFRAME.registerComponent('secondary-camera', {
           this.savedScissorTest = renderer.getScissorTest();
           renderer.getScissor(this.savedScissor);
 
-          const hScale = 0.8 * canvas.width / mainRect.width 
-          const vScale = 0.8 * canvas.height / mainRect.height
+          const pixelRatio = renderer.getPixelRatio()
+          const hScale = (canvas.width / mainRect.width) / pixelRatio
+          const vScale = (canvas.height / mainRect.height) / pixelRatio
+          
           this.outputRectangle.set(hScale * (elemRect.left - mainRect.left),
                                     vScale * (mainRect.bottom - elemRect.bottom),
                                     hScale * elemRect.width,

--- a/tests/multi-screen-with-cursor-capped-canvas-size.html
+++ b/tests/multi-screen-with-cursor-capped-canvas-size.html
@@ -1,0 +1,74 @@
+<!DOCTYPE html>
+<html>
+  <head>
+      <script src="https://aframe.io/releases/1.2.0/aframe.min.js"></script>
+      <script src="../aframe/cursor.js"></script>
+      <script src="../src/multi-camera.js"></script>
+      <script src="../examples/mouse-rotate-controls.js"></script>
+  </head>
+  <body>
+    <div >
+      <a-scene vr-mode-ui="enabled: false"
+               renderer="maxCanvasWidth: 500;
+                         maxCanvasHeight: 500;">
+        <a-entity camera look-controls="enabled:false" position="0 1.6 0"
+                  cursor="rayOrigin: mouse; fuse: false" raycaster="objects: [raycastable]"></a-entity>
+
+        <a-entity id="container" position = "0 0 -4" mouse-rotate-controls>
+          <a-box position="-1 0.5 1" rotation="0 45 0" color="#4CC3D9" raycastable hover></a-box>
+          <a-sphere position="0 1.25 -1" radius="1.25" color="#EF2D5E"raycastable hover></a-sphere>
+          <a-cylinder position="1 0.75 1" radius="0.5" height="1.5" color="#FFC65D" raycastable hover></a-cylinder>
+          <a-plane position="0 0 0" rotation="-90 0 0" width="4" height="4" color="#7BC8A4" side="double" raycastable hover></a-plane>
+
+          <a-entity id="camera1" secondary-camera="outputElement:#viewport1" position="-8 1.6 0" rotation="0 -90 0"
+                    cursor="rayOrigin: mouse; fuse: false; camera: user; canvas: user" raycaster="objects: [raycastable]">
+          </a-entity>
+          <a-entity id="camera2" secondary-camera="outputElement:#viewport2" position="8 1.6 0" rotation="0 90 0"
+                    cursor="rayOrigin: mouse; fuse: false; camera: user; canvas: user" raycaster="objects: [raycastable]">
+          </a-entity>
+          <a-entity id="camera3" secondary-camera="outputElement:#viewport3" position="0 8 0" rotation="-90 0 0"
+                    cursor="rayOrigin: mouse; fuse: false; camera: user; canvas: user" raycaster="objects: [raycastable]">
+          </a-entity>
+
+        </a-entity>
+        <a-sky color="#ECECEC"></a-sky>
+
+        <a-entity id="camera4" secondary-camera="outputElement:#viewport4" position="-8 1.6 -4" rotation="0 -90 0"
+                  cursor="rayOrigin: mouse; fuse: false; camera: user; canvas: user" raycaster="objects: [raycastable]">
+        </a-entity>
+        <a-entity id="camera5" secondary-camera="outputElement:#viewport5" position="8 1.6 -4" rotation="0 90 0"
+                  cursor="rayOrigin: mouse; fuse: false; camera: user; canvas: user" raycaster="objects: [raycastable]">
+        </a-entity>
+        <a-entity id="camera6" secondary-camera="outputElement:#viewport6" position="0 8 -4" rotation="-90 0 0"
+                  cursor="rayOrigin: mouse; fuse: false; camera: user; canvas: user" raycaster="objects: [raycastable]">
+        </a-entity>
+      </a-scene>
+    </div>
+
+
+    <div style="position:absolute; top: 10px; left: 30px; width: 400px; height:200px">
+      These cameras are fixed relative to the objects in the scene.
+    </div>
+    <div id="viewport1" style="position:absolute;  border-style: solid; top: 40px; left: 30px; width: 200px; height:200px">
+    </div>
+    <div id="viewport2" style="position:absolute;  border-style: solid; top: 240px; left: 30px; width: 200px; height:200px">
+    </div>
+    <div id="viewport3"style="position:absolute; border-style: solid; top: 440px; left: 30px; width: 200px; height:200px">
+    </div>
+    <div style="position:absolute; text-align: right; top: 10px; right: 30px; width: 400px; height:200px">
+      These cameras are in fixed world positions.
+    </div>
+    <div id="viewport4" style="position:absolute;  border-style: solid; top: 40px; right: 30px; width: 200px; height:200px">
+    </div>
+    <div id="viewport5" style="position:absolute;  border-style: solid; top: 240px; right: 30px; width: 200px; height:200px">
+    </div>
+    <div id="viewport6"style="position:absolute; border-style: solid; top: 440px; right: 30px; width: 200px; height:200px">
+    </div>
+
+    <div style="position:absolute; text-align: center; top: 10px; left: 200px; right: 200px; width: auto; height:100px">
+      Drag with the mouse to rotate the scene<br/>
+      Hover over an object on any camera to highlight it.
+    </div>
+
+  </body>
+</html>


### PR DESCRIPTION
This is a fix for #6.

It doesn't address this secondary issue...

> It's straightforward to scale the rectangle, but this causes a different issue: the secondary camera views can "bleed" outside its bounds. This is caused both by the canvas interpolation and the fact that the bounds of the target div(s) may not line up with the rendered pixel grid.

...but it's not clear to me that's a problem in all cases, and this fix makes things considerably better, if not perfect.

In working on this, I also spotted another issue which this PR doesn't fix, tracked as #11.